### PR TITLE
chore: migrate to `tooltipTextFunction`

### DIFF
--- a/locale/deDE.lua
+++ b/locale/deDE.lua
@@ -9,6 +9,10 @@ function TitanPanelReputation:LangdeDE()
         ["LID_HOUR_SHORT"] = "h",
         ["LID_HOURS_SHORT"] = "hrs",
 
+        ["LID_TITAN_TOO_OLD_WARNING_BUTTON"] = "oder neuer erforderlich",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_START"] = "Bitte aktualisiere Titan Panel auf Version",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_END"] = "oder neuer, um alle Funktionen freizuschalten.",
+
         -- Labels
         ["LID_ALL_HIDDEN_LABEL"] = "Ruf: Aus",
         ["LID_NO_FACTION_LABEL"] = "Ruf: Keine Fraktion ausgewählt",

--- a/locale/enUS.lua
+++ b/locale/enUS.lua
@@ -15,6 +15,10 @@ function TitanPanelReputation:LangenUS()
         ["LID_HOUR_SHORT"] = "h",
         ["LID_HOURS_SHORT"] = "hrs",
 
+        ["LID_TITAN_TOO_OLD_WARNING_BUTTON"] = "or later required",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_START"] = "Please upgrade Titan Panel to version",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_END"] = "or later to unlock full functionality.",
+
         -- Labels
         ["LID_ALL_HIDDEN_LABEL"] = "Reputation: Off",
         ["LID_NO_FACTION_LABEL"] = "Reputation: No Faction Selected",

--- a/locale/esES.lua
+++ b/locale/esES.lua
@@ -9,6 +9,10 @@ function TitanPanelReputation:LangesES()
         ["LID_HOUR_SHORT"] = "h",
         ["LID_HOURS_SHORT"] = "hrs",
 
+        ["LID_TITAN_TOO_OLD_WARNING_BUTTON"] = "or later required",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_START"] = "Please upgrade Titan Panel to version",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_END"] = "or later to unlock full functionality.",
+
         -- Labels
         ["LID_ALL_HIDDEN_LABEL"] = "Reputation: Off",
         ["LID_NO_FACTION_LABEL"] = "Reputation: No Faction Selected",

--- a/locale/frFR.lua
+++ b/locale/frFR.lua
@@ -9,6 +9,10 @@ function TitanPanelReputation:LangfrFR()
         ["LID_HOUR_SHORT"] = "h",
         ["LID_HOURS_SHORT"] = "hrs",
 
+        ["LID_TITAN_TOO_OLD_WARNING_BUTTON"] = "or later required",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_START"] = "Please upgrade Titan Panel to version",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_END"] = "or later to unlock full functionality.",
+
         -- Labels
         ["LID_ALL_HIDDEN_LABEL"] = "Reputation: Off",
         ["LID_NO_FACTION_LABEL"] = "Reputation: No Faction Selected",

--- a/locale/itIT.lua
+++ b/locale/itIT.lua
@@ -9,6 +9,10 @@ function TitanPanelReputation:LangitIT()
         ["LID_HOUR_SHORT"] = "h",
         ["LID_HOURS_SHORT"] = "hrs",
 
+        ["LID_TITAN_TOO_OLD_WARNING_BUTTON"] = "or later required",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_START"] = "Please upgrade Titan Panel to version",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_END"] = "or later to unlock full functionality.",
+
         -- Labels
         ["LID_ALL_HIDDEN_LABEL"] = "Reputation: Off",
         ["LID_NO_FACTION_LABEL"] = "Reputation: No Faction Selected",

--- a/locale/ptBR.lua
+++ b/locale/ptBR.lua
@@ -9,6 +9,10 @@ function TitanPanelReputation:LangptBR()
         ["LID_HOUR_SHORT"] = "h",
         ["LID_HOURS_SHORT"] = "hrs",
 
+        ["LID_TITAN_TOO_OLD_WARNING_BUTTON"] = "or later required",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_START"] = "Please upgrade Titan Panel to version",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_END"] = "or later to unlock full functionality.",
+
         -- Labels
         ["LID_ALL_HIDDEN_LABEL"] = "Reputation: Off",
         ["LID_NO_FACTION_LABEL"] = "Reputation: No Faction Selected",

--- a/locale/ruRU.lua
+++ b/locale/ruRU.lua
@@ -9,6 +9,10 @@ function TitanPanelReputation:LangruRU()
         ["LID_HOUR_SHORT"] = "ч",
         ["LID_HOURS_SHORT"] = "ч",
 
+        ["LID_TITAN_TOO_OLD_WARNING_BUTTON"] = "or later required",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_START"] = "Please upgrade Titan Panel to version",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_END"] = "or later to unlock full functionality.",
+
         -- Labels
         ["LID_ALL_HIDDEN_LABEL"] = "Репутация: Выключено",
         ["LID_NO_FACTION_LABEL"] = "Репутация: Фракция не выбрана",

--- a/locale/zhCN.lua
+++ b/locale/zhCN.lua
@@ -9,6 +9,10 @@ function TitanPanelReputation:LangzhCN()
         ["LID_HOUR_SHORT"] = "h",
         ["LID_HOURS_SHORT"] = "hrs",
 
+        ["LID_TITAN_TOO_OLD_WARNING_BUTTON"] = "or later required",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_START"] = "Please upgrade Titan Panel to version",
+        ["LID_TITAN_TOO_OLD_WARNING_TOOLTIP_END"] = "or later to unlock full functionality.",
+
         -- Labels
         ["LID_ALL_HIDDEN_LABEL"] = "Reputation: Off",
         ["LID_NO_FACTION_LABEL"] = "Reputation: No Faction Selected",

--- a/src/globals.lua
+++ b/src/globals.lua
@@ -20,7 +20,7 @@ TitanPanelReputation.VERSION = TitanUtils_GetAddOnMetadata("TitanReputation", "V
 ---The title of the addon. This is used to display the title in the Titan Panel.
 ---
 ---@type string
-TitanPanelReputation.TITLE = TitanUtils_GetAddOnMetadata("TitanReputation", "Title")
+TitanPanelReputation.TITLE = "|cffffffffTitan [|cffeda55fReputation Continued|r]|r"
 
 ---
 ---The icon to use for the addon. This is used to display the icon in the Titan Panel,
@@ -35,6 +35,10 @@ TitanPanelReputation.ICON = "Interface\\AddOns\\TitanReputation\\assets\\TitanRe
 ---
 ---@type number
 TitanPanelReputation.INIT_TIME = 0
+
+---Minimum required Titan Panel version (string). Update as needed.
+---@type string
+TitanPanelReputation.MIN_TITAN_VERSION = "9.0.3"
 
 ---
 ---The time passed since TitanPanelReputation was last updated (triggered by an event).

--- a/src/globals.lua
+++ b/src/globals.lua
@@ -38,7 +38,7 @@ TitanPanelReputation.INIT_TIME = 0
 
 ---Minimum required Titan Panel version (string). Update as needed.
 ---@type string
-TitanPanelReputation.MIN_TITAN_VERSION = "9.0.3"
+TitanPanelReputation.MIN_TITAN_VERSION = "9.1.1"
 
 ---
 ---The time passed since TitanPanelReputation was last updated (triggered by an event).

--- a/src/ui/menu.lua
+++ b/src/ui/menu.lua
@@ -258,6 +258,8 @@ end
 ---of this method is important and should read `TitanPanelRightClickMenu_Prepare${TitanPanelReputation.ID}Menu`
 ---
 function TitanPanelRightClickMenu_PrepareReputationMenu()
+    if TitanPanelReputation.TITAN_TOO_OLD then return end
+
     -- Ensure the Blizzard dropdown lists exist before Titan tries to add entries
     EnsureDropDownSeeded()
 

--- a/src/ui/tooltip.lua
+++ b/src/ui/tooltip.lua
@@ -31,11 +31,19 @@ end
 
 
 ---
+---Build the tooltip heading (icon + title + version) as a single string.
+---
+local function BuildTooltipHeading()
+    return "|T" .. TitanPanelReputation.ICON .. ":20|t " .. TitanPanelReputation.TITLE .. " |cff00aa00" .. (TitanPanelReputation.VERSION or "") .. "|r\n"
+end
+
+
+---
 ---Builds the tooltip faction details from the given `FactionDetails` and adds it to the
 ---tooltip text (`TitanPanelReputation.TOOLTIP_TEXT`).
 ---
 ---@param factionDetails FactionDetails
-local function BuildFactionTooltipInfo(factionDetails)
+local function BuildTooltipFactionInfo(factionDetails)
     -- Destructure props from FactionDetails
     local name, standingID, topValue, earnedValue, percent, isHeader, isInactive, hasRep, friendShipReputationInfo, factionID, paragonProgressStarted, headerLevel, headerPath =
         factionDetails.name,
@@ -209,13 +217,13 @@ end
 ---
 ---@return string TitanPanelReputation.TOOLTIP_TEXT  The tooltip text
 function TitanPanelReputation:BuildTooltipText()
-    TitanPanelReputation.TOOLTIP_TEXT = ""
+    TitanPanelReputation.TOOLTIP_TEXT = BuildTooltipHeading()
     TitanPanelReputation.TOTAL_EXALTED = 0
     TitanPanelReputation.TOTAL_BESTFRIENDS = 0
     TitanPanelReputation.LAST_HEADER_PATH = {}
 
     -- Add the faction details to the tooltip text
-    TitanPanelReputation:FactionDetailsProvider(BuildFactionTooltipInfo)
+    TitanPanelReputation:FactionDetailsProvider(BuildTooltipFactionInfo)
 
     -- Build the session summary
     if (TitanGetVar(TitanPanelReputation.ID, "ShowTipSessionSummaryDuration") or TitanGetVar(TitanPanelReputation.ID, "ShowTipSessionSummaryTTL")) then
@@ -296,30 +304,6 @@ function TitanPanelReputation:BuildTooltipText()
     end
 
     return TitanPanelReputation.TOOLTIP_TEXT
-end
-
----
----Adds the given text to the tooltip
----
----@param text string The text to add to the tooltip
-function TitanPanelReputation:AddTooltipText(text)
-    if (text) then
-        -- See if the string is intended for a double column
-        for text1, text2 in string.gmatch(text, "([^\t\n]*)\t?([^\t\n]*)\n") do
-            if (text2 ~= "") then
-                -- Add as double wide
-                GameTooltip:AddDoubleLine(text1, text2)
-            elseif (text1 ~= "") then
-                -- Add single column line
-                GameTooltip:AddLine(text1)
-            else
-                if not TitanGetVar(TitanPanelReputation.ID, "MinimalTip") then
-                    -- Assume a blank line
-                    GameTooltip:AddLine("\n")
-                end
-            end
-        end
-    end
 end
 
 local oldScale; local isTooltipShowing = false

--- a/src/ui/tooltip.lua
+++ b/src/ui/tooltip.lua
@@ -15,8 +15,9 @@ local function EnsureHeaderPathPrinted(headerPath)
     for level, headerName in ipairs(headerPath) do
         if TitanPanelReputation.LAST_HEADER_PATH[level] ~= headerName then
             local indent = string.rep("  ", level - 1)
-            TitanPanelReputation.TOOLTIP_TEXT = TitanPanelReputation.TOOLTIP_TEXT ..
-                "\n" .. indent .. TitanUtils_GetHighlightText(headerName) .. "\n"
+            local prefix = TitanPanelReputation.TOOLTIP_TEXT == "" and "" or "\n"
+
+            TitanPanelReputation.TOOLTIP_TEXT = TitanPanelReputation.TOOLTIP_TEXT .. prefix .. indent .. TitanUtils_GetHighlightText(headerName) .. "\n"
             TitanPanelReputation.LAST_HEADER_PATH[level] = headerName
             for trim = level + 1, #TitanPanelReputation.LAST_HEADER_PATH do
                 TitanPanelReputation.LAST_HEADER_PATH[trim] = nil
@@ -179,8 +180,7 @@ local function BuildTooltipFactionInfo(factionDetails)
                     end
                     if (TitanGetVar(TitanPanelReputation.ID, "ShowTipPercent")) then
                         TitanPanelReputation.TOOLTIP_TEXT = TitanPanelReputation.TOOLTIP_TEXT ..
-                            TitanUtils_GetColoredText(percent .. "%", TitanPanelReputation.BARCOLORS[(adjustedID)]) ..
-                            " "
+                            TitanUtils_GetColoredText(percent .. "%", TitanPanelReputation.BARCOLORS[(adjustedID)]) .. " "
                     end
                     if (TitanGetVar(TitanPanelReputation.ID, "ShowTipStanding")) then
                         TitanPanelReputation.TOOLTIP_TEXT = TitanPanelReputation.TOOLTIP_TEXT ..
@@ -233,15 +233,13 @@ function TitanPanelReputation:BuildTooltipText()
     if (TitanGetVar(TitanPanelReputation.ID, "ShowTipSessionSummaryDuration") or TitanGetVar(TitanPanelReputation.ID, "ShowTipSessionSummaryTTL")) then
         if (next(TitanPanelReputation.RTS) ~= nil) then -- If there are any values in the RTS table
             local sessionTime = GetTime() - TitanPanelReputation.SESSION_TIME_START
-
             local humantime = TitanPanelReputation:GetHumanReadableTime(sessionTime)
 
             TitanPanelReputation.TOOLTIP_TEXT = TitanPanelReputation.TOOLTIP_TEXT ..
                 "\n" ..
                 TitanUtils_GetHighlightText(TitanPanelReputation:GT("LID_SESSION_SUMMARY") .. ":") ..
                 "\t" ..
-                TitanUtils_GetNormalText(TitanPanelReputation:GT("LID_SESSION_SUMMARY_DURATION") ..
-                    ": " .. humantime)
+                TitanUtils_GetNormalText(TitanPanelReputation:GT("LID_SESSION_SUMMARY_DURATION") .. ": " .. humantime)
 
             for f, v in pairs(TitanPanelReputation.RTS) do
                 local RPH_STRING = ""
@@ -293,18 +291,15 @@ function TitanPanelReputation:BuildTooltipText()
 
     -- Build summary of total exalted and best friends
     if (TitanGetVar(TitanPanelReputation.ID, "ShowTipExaltedTotal")) then
-        TitanPanelReputation.TOOLTIP_TEXT = TitanPanelReputation.TOOLTIP_TEXT ..
-            "\n" ..
-            TitanUtils_GetHighlightText(TitanPanelReputation:GT(
-                "LID_SESSION_SUMMARY_TOTAL_EXALTED_FACTIONS") .. ":") ..
-            "\t" ..
+        local prefix = TitanPanelReputation.TOOLTIP_TEXT == "" and "" or "\n"
+        TitanPanelReputation.TOOLTIP_TEXT = TitanPanelReputation.TOOLTIP_TEXT .. prefix ..
+            TitanUtils_GetHighlightText(TitanPanelReputation:GT("LID_SESSION_SUMMARY_TOTAL_EXALTED_FACTIONS") .. ":") .. "\t" ..
             TitanUtils_GetGoldText(TitanPanelReputation:GT("LID_SESSION_SUMMARY_FACTIONS") .. ": ") ..
             TitanUtils_GetGreenText(TitanPanelReputation.TOTAL_EXALTED) ..
             TitanUtils_GetGoldText(" " .. TitanPanelReputation:GT("LID_SESSION_SUMMARY_FRIENDS") .. ": ") ..
             TitanUtils_GetGreenText(TitanPanelReputation.TOTAL_BESTFRIENDS) ..
             TitanUtils_GetGoldText(" " .. TitanPanelReputation:GT("LID_SESSION_SUMMARY_TOTAL") .. ": ") ..
-            TitanUtils_GetGreenText((TitanPanelReputation.TOTAL_EXALTED + TitanPanelReputation.TOTAL_BESTFRIENDS)) ..
-            "\n"
+            TitanUtils_GetGreenText((TitanPanelReputation.TOTAL_EXALTED + TitanPanelReputation.TOTAL_BESTFRIENDS)) .. "\n"
     end
 
     return TitanPanelReputation.TOOLTIP_TEXT

--- a/src/ui/tooltip.lua
+++ b/src/ui/tooltip.lua
@@ -34,7 +34,11 @@ end
 ---Build the tooltip heading (icon + title + version) as a single string.
 ---
 local function BuildTooltipHeading()
-    return "|T" .. TitanPanelReputation.ICON .. ":20|t " .. TitanPanelReputation.TITLE .. " |cff00aa00" .. (TitanPanelReputation.VERSION or "") .. "|r\n"
+    if not TitanGetVar(TitanPanelReputation.ID, "MinimalTip") then
+        return "|T" .. TitanPanelReputation.ICON .. ":20|t " .. TitanPanelReputation.TITLE .. " |cff00aa00" .. (TitanPanelReputation.VERSION or "") .. "|r\n"
+    else
+        return ""
+    end
 end
 
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -145,3 +145,40 @@ function TitanPanelReputation:TrimString(value)
     end
     return value:match("^%s*(.-)%s*$") or ""
 end
+
+---
+---Parses a version string into its numeric components.
+---
+---@param version string The version string to parse
+---@return number[] parts The parsed version components
+---@nodiscard
+function TitanPanelReputation:ParseVersion(version)
+    if not version then return {} end
+    -- Strip non-numeric/dot characters (e.g. @project-version@)
+    version = tostring(version):gsub("[^0-9%.]", "")
+    local parts = {}
+    for num in string.gmatch(version, "(%d+)") do
+        parts[#parts + 1] = tonumber(num)
+    end
+    return parts
+end
+
+---
+---Compares two version strings to determine if the current version is lower than the required version.
+---
+---@param current string The current version string
+---@param required string The required version string
+---@return boolean True if the current version is lower, false otherwise
+---@nodiscard
+function TitanPanelReputation:IsVersionLower(current, required)
+    local a = self:ParseVersion(current)
+    local b = self:ParseVersion(required)
+    local n = math.max(#a, #b)
+    for i = 1, n do
+        local ai = a[i] or 0
+        local bi = b[i] or 0
+        if ai < bi then return true end
+        if ai > bi then return false end
+    end
+    return false
+end


### PR DESCRIPTION
- now uses `tooltipTextFunction` to provide tooltip information, instead of providing our own tooltip (let titan handle the rendering), as the current setup could break with titan v9.1
- added a version check to not load the addon if required titan version is not met, but hint the user